### PR TITLE
Fix URL path in ping-server handler

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1058,7 +1058,7 @@ ipcMain.on("cache-path", (_, cachePath: string) => {
 
 ipcMain.handle("ping-server", (_e, rawUrl: string) => {
   return new Promise<ServerStatusData | null>((resolve, reject) => {
-    const pingUrl = new URL("/api/status", rawUrl).toString();
+    const pingUrl = new URL("api/status", rawUrl).toString();
 
     // fire the request
     const req = net.request(pingUrl);


### PR DESCRIPTION
Client is currently only able to ping instances that are hosted at the root of a domain, but not in subpath, eg.
`https://foundry.example.com` will work, however `https://example.com/fonundry` will ping the wrong address.

This changes the URL resolution to not require absolute path.
