### PR TITLE
Add per-server override for Online Status (closes #11)

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,6 +594,14 @@
                       <i class="fa-solid fa-eye"></i></div></div>
                 </button>
               </div>
+              <div class="server-info-override-field field">
+                <label class="switch-label">Server Status</label>
+                <select class="server-info-override">
+                  <option value="inherit">Use Global Setting</option>
+                  <option value="enabled">Enabled</option>
+                  <option value="disabled">Disabled</option>
+                </select>
+              </div>
               <div class="game-button-group">
                 <button class="save-user-data">Save</button>
                 <button class="delete-game">Delete</button>

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1374,6 +1374,17 @@ async function createGameItem(game: GameConfig) {
     loginData.adminPassword;
   (li.querySelector(".game-name-edit") as HTMLInputElement).value = game.name;
   (li.querySelector(".game-url-edit") as HTMLInputElement).value = game.url;
+  const overrideSelect = li.querySelector(
+    ".server-info-override",
+  ) as HTMLSelectElement | null;
+  if (overrideSelect) {
+    overrideSelect.value =
+      game.serverInfoEnabled === true
+        ? "enabled"
+        : game.serverInfoEnabled === false
+          ? "disabled"
+          : "inherit";
+  }
   li.querySelector("a").innerText = game.name;
   li.querySelector(".game-main-button").addEventListener("click", async () => {
     window.api.openGame(game.id ?? game.name, game.name);
@@ -1387,16 +1398,6 @@ async function createGameItem(game: GameConfig) {
   });
   gameItemList.appendChild(li);
   await updateServerInfos(li, game, seenOffline);
-
-  // Retrieve app config from userData
-  const appConfig = await window.api.localAppConfig();
-  // Hide or display each "Refresh server" button
-  document
-    .querySelectorAll<HTMLElement>(".config-main-button.refresh")
-    .forEach((btn) => {
-      btn.style.display =
-        (appConfig.serverInfoEnabled ?? true) ? "flex" : "none";
-    });
 
   renderTooltips();
   const userConfiguration = li.querySelector(
@@ -1441,6 +1442,18 @@ async function createGameItem(game: GameConfig) {
     const newGameUrl = (
       closeUserConfig.querySelector(".game-url-edit") as HTMLInputElement
     ).value;
+    const overrideValue =
+      (
+        closeUserConfig.querySelector(
+          ".server-info-override",
+        ) as HTMLSelectElement | null
+      )?.value ?? "inherit";
+    const newServerInfoEnabled: boolean | undefined =
+      overrideValue === "enabled"
+        ? true
+        : overrideValue === "disabled"
+          ? false
+          : undefined;
 
     console.log({
       gameId,
@@ -1449,10 +1462,12 @@ async function createGameItem(game: GameConfig) {
       adminPassword,
       newGameName,
       newGameUrl,
+      newServerInfoEnabled,
     });
 
     game.name = newGameName;
     game.url = newGameUrl;
+    game.serverInfoEnabled = newServerInfoEnabled;
 
     (li.querySelector("a") as HTMLAnchorElement).innerText = newGameName;
 
@@ -1461,8 +1476,14 @@ async function createGameItem(game: GameConfig) {
       if (gameToUpdate) {
         gameToUpdate.name = newGameName;
         gameToUpdate.url = newGameUrl;
+        if (newServerInfoEnabled === undefined) {
+          delete gameToUpdate.serverInfoEnabled;
+        } else {
+          gameToUpdate.serverInfoEnabled = newServerInfoEnabled;
+        }
       }
     });
+    await updateServerInfos(li, game, seenOffline);
 
     window.api.saveUserData({
       gameId,
@@ -1924,8 +1945,20 @@ async function updateServerInfos(
   ) as HTMLDivElement | null;
   if (!serverInfos) return;
 
-  // If global toggle is off, hide everything and return
-  if (!serverInfoEnabled) {
+  // Per-server override takes precedence over the global toggle. Falling back
+  // to the global setting keeps existing behavior for games with no override.
+  const effectiveServerInfoEnabled =
+    game.serverInfoEnabled ?? serverInfoEnabled;
+
+  const refreshButton = item.querySelector<HTMLElement>(
+    ".config-main-button.refresh",
+  );
+  if (refreshButton) {
+    refreshButton.style.display =
+      serverInfoEnabled && effectiveServerInfoEnabled ? "flex" : "none";
+  }
+
+  if (!effectiveServerInfoEnabled) {
     serverInfos.style.display = "none";
     return;
   }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -17,6 +17,7 @@ export const GameConfigSchema = z.object({
   url: z.string().optional(),
   id: GameIdSchema.optional(),
   cssId: z.string().optional(),
+  serverInfoEnabled: z.boolean().optional(),
 });
 export type GameConfig = z.infer<typeof GameConfigSchema>;
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,6 +11,7 @@ type GameConfigType = {
   url: string;
   id?: GameId;
   cssId?: string;
+  serverInfoEnabled?: boolean;
 };
 
 type AppConfig = {


### PR DESCRIPTION
## Summary
- Adds an optional `serverInfoEnabled` field to each `GameConfig` so the "Online Status" feature can be overridden on a per-server basis.
- New per-game **Server Status** dropdown (Use Global Setting / Enabled / Disabled) in the game settings panel.
- When set to **Disabled**, the client never pings that server and hides both the status row and its refresh button — independent of the global toggle. Useful for cloud-hosted instances (e.g. Google Cloud Run) where the periodic ping would wake the server and incur cost.
- When set to **Enabled**, the server is pinged even if the global toggle is off.
- When set to **Use Global Setting** (default), behavior is unchanged.

Closes JeidoUran/fvtt-player-client#11

## Test plan
- [x] Open game settings → set Server Status to **Disabled** → save → confirm row + refresh button disappear and no `ping-server` request fires.
- [x] Restart the app → confirm setting is persisted and refresh button stays hidden.
- [x] Toggle global "Enable Server Status" off → confirm a per-server **Enabled** override still pings.
- [x] Toggle global setting back on → per-server **Disabled** still suppresses its ping.
- [x] Existing games without the field continue to behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)